### PR TITLE
데이터베이스에 저장하는 방식 수정 & 저장된 데이터 History 페이지에서 필터링 조회 기능 추가

### DIFF
--- a/back/App.js
+++ b/back/App.js
@@ -3,9 +3,13 @@ const bodyParser = require('body-parser');
 const modbusRoutes = require('./routes/modbusRoutes');
 const sequelize = require('./database/database'); // Sequelize 인스턴스 가져오기
 const app = express();
+const modbusClient = require('./utils/modbusClient');
+
 
 app.use(bodyParser.json());
 app.use('/api/modbus', modbusRoutes);
+
+modbusClient.startPeriodicSave();
 
 sequelize.authenticate()
     .then(() => {

--- a/back/database/database.js
+++ b/back/database/database.js
@@ -9,16 +9,11 @@ const sequelize = new Sequelize(
   process.env.MYSQL_PASSWORD, {
     host: process.env.MYSQL_HOST,
     dialect: 'mysql',
+    timezone: '+09:00', // 서울 시간대
     port: process.env.MYSQL_PORT,
     logging: console.log, // 로깅 설정을 false로 하여 콘솔에 쿼리 로그를 출력하지 않음
   }
 );
-
-// At the end of database.js
-console.log('Exporting sequelize instance:', sequelize);
-
-// At the beginning of temperatureRecord.js
-console.log('Imported sequelize instance:', sequelize);
 
 
 // 연결 테스트

--- a/back/routes/modbusRoutes.js
+++ b/back/routes/modbusRoutes.js
@@ -7,6 +7,7 @@ router.get('/read-setting-temperature', modbusController.readSetTemperature);
 router.post('/write-set-temperature', modbusController.writeSetTemperature);
 router.get('/read-thermostat-status', modbusController.readThermostatStatus);
 router.post('/write-thermostat-control', modbusController.writeThermostatControl);
-//router.post('/save-current-temperature', modbusController.saveCurrentTemperature);
+
+router.get('/temperature-history', modbusController.readTemperatureHistory);
 
 module.exports = router;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -19,6 +19,7 @@
         "chartjs-adapter-moment": "^1.0.1",
         "dotenv": "^16.4.1",
         "moment": "^2.30.1",
+        "moment-timezone": "^0.5.44",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
@@ -12765,6 +12766,17 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.44",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.44.tgz",
+      "integrity": "sha512-nv3YpzI/8lkQn0U6RkLd+f0W/zy/JnoR5/EyPz/dNkPTBjA2jNLCVxaiQ8QpeLymhSZvX0wCL5s27NQWdOPwAw==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
       "engines": {
         "node": "*"
       }

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
     "chartjs-adapter-moment": "^1.0.1",
     "dotenv": "^16.4.1",
     "moment": "^2.30.1",
+    "moment-timezone": "^0.5.44",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",

--- a/front/src/pages/Home.js
+++ b/front/src/pages/Home.js
@@ -48,10 +48,11 @@ const Home = () => {
     const [tempStatus, setTempStatus] = useState(false);
     const [refreshSettingTemp, setRefreshSettingTemp] = useState(false);
     const [currentTempData, setCurrentTempData] = useState([]);
-    const [refreshInterval, setRefreshInterval] = useState(5000); // 기본값을 5초로 설정
+    const [refreshInterval, setRefreshInterval] = useState(10000); // 기본값을 10초로 설정
 
     // 데이터 소수점 처리
     const convertTemperature = (temp) => temp / 10;
+
 
     useEffect(() => {
         readSettingTemperature().then(response => {
@@ -59,16 +60,25 @@ const Home = () => {
         }).catch(error => console.error('Error:', error));
     }, [refreshSettingTemp]);
 
+
     useEffect(() => {
         const interval = setInterval(() => {
             readCurrentTemperature().then(response => {
                 const temp = convertTemperature(response.data);
                 setCurrentTemp(temp);
-                setCurrentTempData(prevData => [...prevData, { x: moment().valueOf(), y: temp }]);
+
+                setCurrentTempData(prevData => {
+                    const newData = [...prevData, { x: moment().valueOf(), y: temp }]
+                    if (newData.length > 60) {
+                        newData.shift(); // 배열의 첫 번째 요소 제거 -> 최소 10분(10초일 때) 
+                    }
+                    return newData;
+                });
             }).catch(error => console.error('Error:', error));
         }, refreshInterval);
         return () => clearInterval(interval);
     }, [refreshInterval]);
+
 
     useEffect(() => {
         readThermostatStatus().then(response => {
@@ -76,10 +86,12 @@ const Home = () => {
         }).catch(error => console.error('Error:', error));
     }, [tempStatus]);
 
+
     // 설정 온도 변경
     const handleSetTempChange = (e) => {
         setSetTemp(e.target.value);
     };
+
 
     // 설정 온도 변경
     const handleSetTempSubmit = () => {
@@ -201,7 +213,6 @@ const Home = () => {
                         <InputContainer>
                         <Label>데이터 주기</Label>
                             <Select value={refreshInterval} onChange={handleIntervalChange}>
-                                <option value="5000">5초</option>
                                 <option value="10000">10초</option>
                                 <option value="30000">30초</option>
                                 <option value="60000">1분</option>

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -24,3 +24,10 @@ export const readThermostatStatus = async () => {
 export const writeThermostatControl = async (value) => {
     return axios.post('/api/modbus/write-thermostat-control', { value });
 };
+
+// 온도 기록을 읽어오는 API 호출
+export const readTemperatureHistory = async (startDate, endDate) => {
+    return axios.get('/api/modbus/temperature-history', {
+        params: { startDate, endDate }
+    });
+};


### PR DESCRIPTION
### 프론트엔드
1. History 페이지 구성
조회 시작 기간, 끝 기간을 선택하고 조회버튼을 누르면 Node.js(백엔드) 서버에 API 호출

2. Main 페이지 그래프 방식 수정 & read 주기 5초 -> 10초
(기존) 모니터링할때부터 끝날때까지 모든 데이터를 그래프 -> (변경) 10초 주기  60개의 데이터만 나오도록 수정

### 백엔드
1. DB에 저장 방식 변경
(기존) 클라이언트에서 현재 온도 읽기 요청이 들어오면 DB에 저장 -> (변경) 읽기 요청에서 분리 & 10초에 한번씩 DB에 저장

2. DB에 저장할 때 실제 온도값처럼 소수점 처리하여 저장 

3. DB에 저장할 때 시간이 잘못 저장되던 오류 해결
프론트 History 페이지에서 조회를 할 때 시간대가 맞지 않아 원인을 파악하던 중 발견
DB서버 시간 확인(Select now()) -> 백엔드 시간 확인 -> 다시 DB데이터 확인 -> DB와 백엔드 둘다 시간대가 같음 -> 계속 시간이 잘못 저장됨 -> Sequleize에서 시간대 설정을 하지않음 -> sequelize에서 timezone: '+09:00' 설정을 하여 해결